### PR TITLE
move faker out of dev env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,11 +52,12 @@ gem "devise"
 gem "autoprefixer-rails"
 gem "font-awesome-sass", "~> 6.1"
 gem "simple_form", github: "heartcombo/simple_form"
+gem "faker"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "dotenv-rails"
-  gem "faker"
 end
 
 group :development do


### PR DESCRIPTION
# Description

Moved faker gem out of dev env section so that seed file works on Heroku.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Screenshot A
<img width="469" alt="Screen Shot 2023-03-24 at 2 24 19 PM" src="https://user-images.githubusercontent.com/115083635/227442104-f3987646-7ac1-472f-82a3-85bad5ee6e5f.png">



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
