### PR TITLE
removed unecessary breaking migration

### DIFF
--- a/db/migrate/20230324031041_rename_active_to_shortlisted_in_pathways.rb
+++ b/db/migrate/20230324031041_rename_active_to_shortlisted_in_pathways.rb
@@ -1,5 +1,0 @@
-class RenameActiveToShortlistedInPathways < ActiveRecord::Migration[7.0]
-  def change
-    rename_column :pathways, :active, :shortlisted
-  end
-end


### PR DESCRIPTION
# Description

Unable to run migration because of a conflicting migration file. Since pathways are now created on the careers index, removed unecessary change to the unused 'active' column to fix issues.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
